### PR TITLE
Clear the chat box immediately upon submitting a new message

### DIFF
--- a/app/assets/javascripts/backbone/views/rooms/show_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/rooms/show_view.js.coffee
@@ -31,13 +31,9 @@ class Chamber.Views.Rooms.ShowView extends Backbone.View
     @options.messages.create({
       body: body,
       room_id: room.id,
-    }, {
-      silent: true, 
-      success: ->
-        # Clear the input field
-        input.val('')
-    })
+    }, { silent: true })
+
+    input.val("")
 
     e.preventDefault()
     return false
-    


### PR DESCRIPTION
We should clear the chat box immediately upon submitting a new message so as to avoid clearing it when the user has already started typing a new one.
